### PR TITLE
Fix jq usage for jq < 1.6

### DIFF
--- a/tests/framework.bash
+++ b/tests/framework.bash
@@ -63,7 +63,7 @@ expect() {
     return 1
   fi
 
-  diff <(echo "$result" | jq -S) <(echo "$expected_result" | jq -S)
+  diff <(echo "$result" | jq -S .) <(echo "$expected_result" | jq -S .)
 }
 
 field-exists() {
@@ -111,7 +111,7 @@ JSON
 
 is-json() {
   local content=$1
-  if ! echo "$content" | jq >/dev/null; then
+  if ! echo "$content" | jq . >/dev/null; then
     return 1
   else
     # an empty response shouldn't be classified as valid JSON


### PR DESCRIPTION
Only since jq 1.6 the default selector is '.' - beforehand there wasn't
any selector. Thus with jq < 1.6 the tests will fail. Since even the
newest Ubuntu version in this point of time ships jq 1.5, we should fix
this.

See https://github.com/stedolan/jq/releases/tag/jq-1.6:

> Calling jq without a program argument now always assumes . for the
> program, regardless of stdin/stdout.